### PR TITLE
Help non-lyft folks run metadataproxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ EXPOSE 8000
 VOLUME ["/var/run/docker.sock"]
 
 WORKDIR /srv/metadataproxy
-CMD ["gunicorn", "metadataproxy:app", "--workers=2", "-k", "gevent"]
+CMD ["/bin/sh", "run-server.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,11 @@
-FROM lyft/gunicorn:df28a20af3e2ea3d006859b4da2034d36d4fa028
-COPY requirements.txt /code/metadataproxy/requirements.txt
-RUN /code/containers/python/pip-installer /code/metadataproxy/requirements.txt
-COPY . /code/metadataproxy/
+FROM python:2.7.11
+COPY . /srv/metadataproxy/
+
+RUN pip --no-cache-dir install -r /srv/metadataproxy/requirements.txt && \
+    pip --no-cache-dir install -r /srv/metadataproxy/requirements_wsgi.txt
+
+EXPOSE 8000
+VOLUME ["/var/run/docker.sock"]
+
+WORKDIR /srv/metadataproxy
+CMD ["gunicorn", "metadataproxy:app", "--workers=2", "-k", "gevent"]

--- a/README.md
+++ b/README.md
@@ -137,6 +137,5 @@ You can build one with the included Dockerfile.  To run, do something like:
 ```bash
 docker run --net=host \
     -v /var/run/docker.sock:/var/run/docker.sock \
-    -e MOCK_API=true \
     metadataproxy
 ```

--- a/README.md
+++ b/README.md
@@ -75,6 +75,17 @@ If you'd like to start the metadataproxy in a container, it's recommended to
 use host-only networking. Also, it's necessary to volume mount in the docker
 socket, as metadataproxy must be able to interact with docker.
 
+Be aware that non-host-mode containers will not be able to contact
+127.0.0.1 in the host network stack.  As an alternative, you can use
+the meta-data service to find the local address.  In this case, you
+probably want to restrict proxy access to the docker0 interface!
+
+```
+LOCAL_IPV4=$(curl http://169.254.169.254/latest/meta-data/local-ipv4)
+/sbin/iptables --wait -t nat -A PREROUTING  -i docker0 -p tcp --dport 80 --destination 169.254.169.254 --jump DNAT --to-destination $LOCAL_IPV4:8000
+/sbin/iptables --wait -I INPUT 1 -p tcp --dport 80 \! -i docker0 -j DROP
+```
+
 ## Run metadataproxy without docker
 
 In the following we assume _my\_config_ is a bash file with exports for all of

--- a/README.md
+++ b/README.md
@@ -61,6 +61,38 @@ you can use the following configuration option:
 export DEFAULT_ROLE=my-default-role
 ```
 
+### Role structure
+
+A useful way to deploy this metadataproxy is with a two-tier role
+structure:
+
+1.  The first tier is the EC2 service role for the instances running
+    your containers.  Call it `DockerHostRole`.  Your instances must
+    be launched with a policy that assigns this role.
+
+2.  The second tier is the role that each container will use.  These
+    roles must trust your own account ("Role for Cross-Account
+    Access" in AWS terms).  Call it `ContainerRole1`.
+
+3.  metadataproxy needs to query and assume the container role.  So
+    the `DockerHostRole` policy must permit this for each container
+    role.  For example:
+    ```
+    "Statement": [ {
+        "Effect": "Allow",
+        "Action": [
+            "iam:GetRole",
+            "sts:AssumeRole"
+        ],
+        "Resource": [
+            "arn:aws:iam::012345678901:role/ContainerRole1",
+            "arn:aws:iam::012345678901:role/ContainerRole2"
+        ]
+    } ]
+    ```
+
+4. Now customize `ContainerRole1` & friends as you like
+
 ### Routing container traffic to metadataproxy
 
 Using iptables, we can forward traffic meant to 169.254.169.254 from docker0 to

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ If you'd like to start the metadataproxy in a container, it's recommended to
 use host-only networking. Also, it's necessary to volume mount in the docker
 socket, as metadataproxy must be able to interact with docker.
 
-## Run metadataproxy
+## Run metadataproxy without docker
 
 In the following we assume _my\_config_ is a bash file with exports for all of
 the necessary settings discussed in the configuration section.
@@ -84,5 +84,16 @@ the necessary settings discussed in the configuration section.
 source my_config
 cd /srv/metadataproxy
 source venv/bin/activate
-gunicorn wsgi:app --workers=2 -k gevent
+gunicorn metadataproxy:app --workers=2 -k gevent
+```
+
+## Run metadataproxy with docker
+
+For production purposes, you'll want to kick up a container to run.
+You can build one with the included Dockerfile.  To run, do something like:
+```bash
+docker run --net=host \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -e MOCK_API=true \
+    metadataproxy
 ```

--- a/run-server.sh
+++ b/run-server.sh
@@ -1,0 +1,11 @@
+#!/bin/sh -e
+
+if [ "z$HOST" = "z" ]; then
+    HOST="0.0.0.0"
+fi
+
+if [ "z$PORT" = "z" ]; then
+    PORT=8000
+fi
+
+/usr/local/bin/gunicorn metadataproxy:app --workers=2 -k gevent -b $HOST:$PORT


### PR DESCRIPTION
As it currently stands, metadataproxy requires access to private lyft images which provide a lot of the startup config for metadataproxy.  This includes changes to run metadataproxy without lyft's gunicorn container config.