### PR TITLE
Add private Dockerfile for metadataproxy

### DIFF
--- a/Dockerfile.private
+++ b/Dockerfile.private
@@ -1,0 +1,4 @@
+FROM lyft/gunicorn:df28a20af3e2ea3d006859b4da2034d36d4fa028
+COPY requirements.txt /code/metadataproxy/requirements.txt
+RUN /code/containers/python/pip-installer /code/metadataproxy/requirements.txt
+COPY . /code/metadataproxy/


### PR DESCRIPTION
Add private Dockerfile for metadataproxy so that default Dockerfile can be the public, third-party usable file