### PR TITLE
Support environment variables that do not have a value

### DIFF
--- a/metadataproxy/roles.py
+++ b/metadataproxy/roles.py
@@ -92,7 +92,7 @@ def get_role_name_from_ip(ip):
     if container:
         env = container['Config']['Env']
         for e in env:
-            key, val = e.split('=', 1)
+            key, _, val = e.partition('=')
             if key == 'IAM_ROLE':
                 return val
         return app.config['DEFAULT_ROLE']


### PR DESCRIPTION
I have an environment variable with no value. Here's a snippet:

```
        "Config": {
            "Env": [
                "TERM=xterm",
                "HOST_PRIVATE_IP_ADDRESS",         <--
                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
            ],
        }
```

This variable makes `get_role_name_from_ip` fail, because `split()` returns 1 item instead of the expected 2. The fix below uses `partition()` instead of `split()`, which will always return a 3-tuple.

```
>>> e1 = 'TERM=xterm'
>>> e2 = 'HOST_PRIVATE_IP_ADDRESS'
>>> e1.split('=')
['TERM', 'xterm']
>>> e2.split('=')
['HOST_PRIVATE_IP_ADDRESS']
>>> e1.partition('=')
('TERM', '=', 'xterm')
>>> e2.partition('=')
('HOST_PRIVATE_IP_ADDRESS', '', '')
```