### PR TITLE
Behavior fixes

### DIFF
--- a/metadataproxy/routes/proxy.py
+++ b/metadataproxy/routes/proxy.py
@@ -23,8 +23,9 @@ def _supports_iam(version):
     '''
     return version >= '2012-01-12'
 
-@app.route('/<api_version>/meta-data/iam/info')
-def iam_role_info(api_version):
+@app.route('/<api_version>/meta-data/iam/info', strict_slashes=False)
+@app.route('/<api_version>/meta-data/iam/info/<path:junk>')
+def iam_role_info(api_version, junk=None):
     if not _supports_iam(api_version):
         return passthrough(request.path)
 
@@ -48,8 +49,10 @@ def iam_role_name(api_version):
         log.error('Role name not found; returning 404.')
         return '', 404
 
-@app.route('/<api_version>/meta-data/iam/security-credentials/<requested_role>')
-def iam_sts_credentials(api_version, requested_role):
+@app.route('/<api_version>/meta-data/iam/security-credentials/<requested_role>',
+           strict_slashes=False)
+@app.route('/<api_version>/meta-data/iam/security-credentials/<requested_role>/<path:junk>')
+def iam_sts_credentials(api_version, requested_role, junk=None):
     if not _supports_iam(api_version):
         return passthrough(request.path)
 

--- a/metadataproxy/routes/proxy.py
+++ b/metadataproxy/routes/proxy.py
@@ -12,8 +12,22 @@ from metadataproxy import app
 from metadataproxy import log
 from metadataproxy import roles
 
+
+def _supports_iam(version):
+    '''Check the meta-data version for IAM support
+
+    API versions before 2012-01-12 don't support the iam/ subtree.
+    This function works because:
+    >>> '1.0' < '2007-01-19' < '2014-11-05' < 'latest'
+    True
+    '''
+    return version >= '2012-01-12'
+
 @app.route('/<api_version>/meta-data/iam/info')
 def iam_role_info(api_version):
+    if not _supports_iam(api_version):
+        return passthrough(request.path)
+
     role_name_from_ip = roles.get_role_name_from_ip(request.remote_addr)
     if role_name_from_ip:
         log.debug('Providing IAM role info for {0}'.format(role_name_from_ip))
@@ -24,6 +38,9 @@ def iam_role_info(api_version):
 
 @app.route('/<api_version>/meta-data/iam/security-credentials/')
 def iam_role_name(api_version):
+    if not _supports_iam(api_version):
+        return passthrough(request.path)
+
     role_name_from_ip = roles.get_role_name_from_ip(request.remote_addr)
     if role_name_from_ip:
         return role_name_from_ip
@@ -33,6 +50,9 @@ def iam_role_name(api_version):
 
 @app.route('/<api_version>/meta-data/iam/security-credentials/<requested_role>')
 def iam_sts_credentials(api_version, requested_role):
+    if not _supports_iam(api_version):
+        return passthrough(request.path)
+
     if not roles.check_role_name_from_ip(request.remote_addr, requested_role):
         msg = "Role name {0} doesn't match expected role for container"
         log.error(msg.format(requested_role))


### PR DESCRIPTION
While troubleshooting an issue where containers get host role credentials, I found two ways in which metadataproxy differs from the upstream meta-data service.  In brief these changes:
1) Don't answer IAM requests for meta-data API versions that don't support IAM.
2) Follow AWS behavior when a client request has some trailing garbage
3) Use the DEBUG environment variable to get logs.

I think the second item is the fix I need - without it, metadataproxy leaks the host role.  But I don't have a good reproducible case there.

Thanks,
Ross