### PR TITLE
Support assuming roles across accounts

### DIFF
--- a/metadataproxy/roles.py
+++ b/metadataproxy/roles.py
@@ -223,7 +223,7 @@ def get_role_arn(role_name):
     # in and use that.
     account_id = app.config['AWS_ACCOUNT_MAP'].get(account_name, account_name)
     # Return a generated ARN
-    return 'arn:aws:iam::{0}:role/{1}'.format(assume_role, account_id)
+    return 'arn:aws:iam::{0}:role/{1}'.format(account_id, assume_role)
 
 
 @log_exec_time

--- a/metadataproxy/roles.py
+++ b/metadataproxy/roles.py
@@ -141,6 +141,13 @@ def find_container(ip):
     return None
 
 
+def check_role_name_from_ip(ip, requested_role):
+    role_name = get_role_name_from_ip(ip)
+    if role_name == requested_role:
+        return True
+    return False
+
+
 @log_exec_time
 def get_role_name_from_ip(ip, stripped=True):
     if app.config['ROLE_MAPPING_FILE']:

--- a/metadataproxy/roles.py
+++ b/metadataproxy/roles.py
@@ -142,7 +142,7 @@ def find_container(ip):
 
 
 @log_exec_time
-def get_role_name_from_ip(ip):
+def get_role_name_from_ip(ip, stripped=True):
     if app.config['ROLE_MAPPING_FILE']:
         return ROLE_MAPPINGS.get(ip, app.config['DEFAULT_ROLE'])
     container = find_container(ip)
@@ -151,17 +151,23 @@ def get_role_name_from_ip(ip):
         for e in env:
             key, val = e.split('=', 1)
             if key == 'IAM_ROLE':
-                return val
+                if stripped:
+                    return val.split('@')[0]
+                else:
+                    return val
         msg = "Couldn't find IAM_ROLE variable. Returning DEFAULT_ROLE: {0}"
         log.debug(msg.format(app.config['DEFAULT_ROLE']))
-        return app.config['DEFAULT_ROLE']
+        if stripped:
+            return app.config['DEFAULT_ROLE'].split('@')[0]
+        else:
+            return app.config['DEFAULT_ROLE']
     else:
         return None
 
 
 @log_exec_time
 def get_role_info_from_ip(ip):
-    role_name = get_role_name_from_ip(ip)
+    role_name = get_role_name_from_ip(ip, stripped=False)
     if not role_name:
         return {}
     try:

--- a/metadataproxy/routes/mock.py
+++ b/metadataproxy/routes/mock.py
@@ -6,8 +6,8 @@ from flask import redirect
 from flask import url_for
 from flask import jsonify
 
-
 from metadataproxy import app
+from metadataproxy import log
 from metadataproxy import roles
 from metadataproxy.roles import GetRoleError
 
@@ -110,9 +110,13 @@ def get_iam_slash(api_version):
 
 @app.route('/<api_version>/meta-data/iam/info')
 def get_iam_info(api_version):
-    return jsonify(
-        roles.get_role_info_from_ip(request.remote_addr)
-    )
+    role_name_from_ip = roles.get_role_name_from_ip(request.remote_addr)
+    if role_name_from_ip:
+        log.debug('Providing IAM role info for {0}'.format(role_name_from_ip))
+        return jsonify(roles.get_role_info_from_ip(request.remote_addr))
+    else:
+        log.error('Role name not found; returning 404.')
+        return '', 404
 
 
 @app.route('/<api_version>/meta-data/iam/security-credentials')
@@ -136,12 +140,15 @@ def get_security_credentials_slash(api_version):
     methods=['GET']
 )
 def get_role_credentials(api_version, requested_role):
-    role_name = roles.get_role_name_from_ip(request.remote_addr)
-    if role_name != requested_role:
+    if not roles.check_role_name_from_ip(request.remote_addr, requested_role):
         return '', 403
+    role_name = roles.get_role_name_from_ip(
+        request.remote_addr,
+        stripped=False
+    )
     try:
         assumed_role = roles.get_assumed_role_credentials(
-            requested_role=requested_role,
+            requested_role=role_name,
             api_version=api_version
         )
     except GetRoleError as e:

--- a/metadataproxy/routes/mock.py
+++ b/metadataproxy/routes/mock.py
@@ -140,7 +140,7 @@ def get_role_credentials(api_version, requested_role):
     if role_name != requested_role:
         return '', 403
     try:
-        assumed_role = roles.get_assumed_role(
+        assumed_role = roles.get_assumed_role_credentials(
             requested_role=requested_role,
             api_version=api_version
         )

--- a/metadataproxy/routes/proxy.py
+++ b/metadataproxy/routes/proxy.py
@@ -39,7 +39,7 @@ def iam_sts_credentials(api_version, role_name):
         log.error(msg.format(role_name, role_name_from_ip))
         return '', 404
     log.debug('Providing assumed role credentials for {0}'.format(role_name))
-    assumed_role = roles.get_assumed_role(
+    assumed_role = roles.get_assumed_role_credentials(
         requested_role=role_name,
         api_version=api_version
     )

--- a/metadataproxy/routes/proxy.py
+++ b/metadataproxy/routes/proxy.py
@@ -31,13 +31,16 @@ def iam_role_name(api_version):
         log.error('Role name not found; returning 404.')
         return '', 404
 
-@app.route('/<api_version>/meta-data/iam/security-credentials/<role_name>')
-def iam_sts_credentials(api_version, role_name):
-    role_name_from_ip = roles.get_role_name_from_ip(request.remote_addr)
-    if role_name_from_ip != role_name:
-        msg = "Role name {0} doesn't match expected role for container {1}"
-        log.error(msg.format(role_name, role_name_from_ip))
+@app.route('/<api_version>/meta-data/iam/security-credentials/<requested_role>')
+def iam_sts_credentials(api_version, requested_role):
+    if not roles.check_role_name_from_ip(request.remote_addr, requested_role):
+        msg = "Role name {0} doesn't match expected role for container"
+        log.error(msg.format(requested_role))
         return '', 404
+    role_name = roles.get_role_name_from_ip(
+        request.remote_addr,
+        stripped=False
+    )
     log.debug('Providing assumed role credentials for {0}'.format(role_name))
     assumed_role = roles.get_assumed_role_credentials(
         requested_role=role_name,

--- a/metadataproxy/settings.py
+++ b/metadataproxy/settings.py
@@ -1,3 +1,4 @@
+import json
 from os import getenv
 
 
@@ -52,14 +53,48 @@ def str_env(var_name, default=''):
     return getenv(var_name, default)
 
 
-DEFAULT_ROLE = str_env('DEFAULT_ROLE')
 PORT = int_env('PORT', 45001)
 HOST = str_env('HOST', '0.0.0.0')
 DEBUG = bool_env('DEBUG', True)
-MOCK_API = bool_env('MOCK_API', False)
-METADATA_URL = str_env('METADATA_URL', 'http://169.254.169.254')
-MOCKED_INSTANCE_ID = str_env('MOCKED_INSTANCE_ID', 'mockedid')
-ROLE_MAPPING_FILE = str_env('ROLE_MAPPING_FILE')
-ROLE_REVERSE_LOOKUP = bool_env('ROLE_REVERSE_LOOKUP', False)
-HOSTNAME_MATCH_REGEX = str_env('HOSTNAME_MATCH_REGEX', '^.*$')
+
+# Url of the docker daemon. The default is to access docker via its socket.
 DOCKER_URL = str_env('DOCKER_URL', 'unix://var/run/docker.sock')
+# URL of the metadata service. Default is the normal location of the
+# metadata service in AWS.
+METADATA_URL = str_env('METADATA_URL', 'http://169.254.169.254')
+# Whether or not to mock all metadata endpoints. If True, mocked data will be
+# returned to callers. If False, all endpoints except for IAM endpoints will be
+# proxied through to the real metadata service.
+MOCK_API = bool_env('MOCK_API', False)
+# When mocking the API, use the following instance id in returned data.
+MOCKED_INSTANCE_ID = str_env('MOCKED_INSTANCE_ID', 'mockedid')
+
+# Role to use if IAM_ROLE is not set in a container's environment. If unset
+# the container will get no IAM credentials.
+DEFAULT_ROLE = str_env('DEFAULT_ROLE')
+# The default account ID to assume roles in, if IAM_ROLE does not contain
+# account information. If unset, metadataproxy will attempt to lookup role
+# ARNs using IAM:GET_ROLE, if the IAM_ROLE name is not an ARN.
+DEFAULT_ACCOUNT_ID = str_env('DEFAULT_ACCOUNT_ID')
+# A mapping of account names to account IDs. This allows you to use
+# user-friendly names in the IAM_ROLE environment variable; for instance:
+#
+#   AWS_ACCOUNT_MAP={'my-account-name':'12345'}
+#
+# A lookup of myrole@my-account-name would map to
+#
+#   role_name: myrole
+#   account_id: 12345
+AWS_ACCOUNT_MAP = json.loads(str_env('AWS_ACCOUNT_MAP', '{}'))
+
+# A json file that has a dict mapping of IP addresses to role names. Can be
+# used if docker networking has been disabled and you are managing IP
+# addressing for containers through another process.
+ROLE_MAPPING_FILE = str_env('ROLE_MAPPING_FILE')
+# Do a reverse lookup of incoming IP addresses to match containers by hostname.
+# Useful if you've disabled networking in docker, but set hostnames for
+# containers in /etc/hosts or DNS.
+ROLE_REVERSE_LOOKUP = bool_env('ROLE_REVERSE_LOOKUP', False)
+# Limit reverse lookup container matching to hostnames that match the specified
+# pattern.
+HOSTNAME_MATCH_REGEX = str_env('HOSTNAME_MATCH_REGEX', '^.*$')


### PR DESCRIPTION
This change adds support for assuming cross-account roles. The refactor also makes it possible to drop IAM:GET_ROLE permissions from metadataproxy's IAM role/user. Two new settings are added:

* DEFAULT_ACCOUNT_ID
* AWS_ACCOUNT_MAP

The behavior change here is reflected in the IAM_ROLE environment variable that's set. So, for instance the following environment variable uses a role in the default account:

```
IAM_ROLE=my-service-role
```

The following environment variable uses a role in another account:

```
IAM_ROLE=my-service-role@12345
```

By setting AWS_ACCOUNT_MAP it's possible to refer to accounts by a user-friendly name, rather than an ID:

```
export AWS_ACCOUNT_MAP='{"primary-account":"12345","security-account":"98765"}'
```

Then you can set an environment variable like the following:

```
IAM_ROLE=my-service-role@primary-account
```

This change also makes it possible to simply provide ARNs in your IAM_ROLE variable:

```
IAM_ROLE=arn:aws:iam::12345:role/my-service-role
```