### PR TITLE
Handle cached containers that are stopped

### DIFF
--- a/metadataproxy/roles.py
+++ b/metadataproxy/roles.py
@@ -90,7 +90,12 @@ def find_container(ip):
         try:
             with PrintingBlockTimer('Container inspect'):
                 container = client.inspect_container(CONTAINER_MAPPING[ip])
-            return container
+            # Only return a cached container if it is running.
+            if container['State']['Running']:
+                return container
+            else:
+                log.error('Container id {0} is no longger running'.format(ip))
+                del CONTAINER_MAPPING[ip]
         except docker.errors.NotFound:
             msg = 'Container id {0} no longer mapped to {1}'
             log.error(msg.format(CONTAINER_MAPPING[ip], ip))


### PR DESCRIPTION
Pull Request for Issue #19

This change checks to see if the cached container is running and if its not, removes it from the cache. 

This will 1, prevent returning the role for the last container that had it's ip address and 2 help keep the cache clean of stopped containers.  