### PR TITLE
Auto-set the docker client version

### DIFF
--- a/metadataproxy/roles.py
+++ b/metadataproxy/roles.py
@@ -62,7 +62,8 @@ def log_exec_time(method):
 def docker_client():
     global _docker_client
     if _docker_client is None:
-        _docker_client = docker.Client(base_url=app.config['DOCKER_URL'])
+        _docker_client = docker.Client(base_url=app.config['DOCKER_URL'],
+                                       version=app.config['DOCKER_VERSION'])
     return _docker_client
 
 

--- a/metadataproxy/settings.py
+++ b/metadataproxy/settings.py
@@ -59,6 +59,8 @@ DEBUG = bool_env('DEBUG', True)
 
 # Url of the docker daemon. The default is to access docker via its socket.
 DOCKER_URL = str_env('DOCKER_URL', 'unix://var/run/docker.sock')
+# Version of the docker client. The default is to match the server.
+DOCKER_VERSION = str_env('DOCKER_VERSION', 'auto')
 # URL of the metadata service. Default is the normal location of the
 # metadata service in AWS.
 METADATA_URL = str_env('METADATA_URL', 'http://169.254.169.254')


### PR DESCRIPTION
As currently written, using an older docker version on the server side of the socket raise an exception:

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/gunicorn/workers/async.py", line 52, in handle
    self.handle_request(listener_name, req, client, addr)
  File "/usr/lib/python2.7/site-packages/gunicorn/workers/ggevent.py", line 159, in handle_request
    super(GeventWorker, self).handle_request(*args)
  File "/usr/lib/python2.7/site-packages/gunicorn/workers/async.py", line 105, in handle_request
    respiter = self.wsgi(environ, resp.start_response)
  File "/usr/lib/python2.7/site-packages/flask/app.py", line 1836, in __call__
    return self.wsgi_app(environ, start_response)
  File "/usr/lib/python2.7/site-packages/flask/app.py", line 1820, in wsgi_app
    response = self.make_response(self.handle_exception(e))
  File "/usr/lib/python2.7/site-packages/flask/app.py", line 1403, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/lib/python2.7/site-packages/flask/app.py", line 1817, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/lib/python2.7/site-packages/flask/app.py", line 1477, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/lib/python2.7/site-packages/flask/app.py", line 1381, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/lib/python2.7/site-packages/flask/app.py", line 1475, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/lib/python2.7/site-packages/flask/app.py", line 1461, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/usr/lib/python2.7/site-packages/metadataproxy/routes/proxy.py", line 44, in iam_role_name
    role_name_from_ip = roles.get_role_name_from_ip(request.remote_addr)
  File "/usr/lib/python2.7/site-packages/metadataproxy/roles.py", line 57, in timed
    result = method(*args, **kw)
  File "/usr/lib/python2.7/site-packages/metadataproxy/roles.py", line 160, in get_role_name_from_ip
    container = find_container(ip)
  File "/usr/lib/python2.7/site-packages/metadataproxy/roles.py", line 57, in timed
    result = method(*args, **kw)
  File "/usr/lib/python2.7/site-packages/metadataproxy/roles.py", line 114, in find_container
    _ids = [c['Id'] for c in client.containers()]
  File "/usr/lib/python2.7/site-packages/docker/api/container.py", line 70, in containers
    res = self._result(self._get(u, params=params), True)
  File "/usr/lib/python2.7/site-packages/docker/client.py", line 178, in _result
    self._raise_for_status(response)
  File "/usr/lib/python2.7/site-packages/docker/client.py", line 174, in _raise_for_status
    raise errors.APIError(e, response, explanation=explanation)
APIError: 400 Client Error: Bad Request ("client is newer than server (client API version: 1.22, server API version: 1.21)")
```

This easily fixed by allowing `docker.Client` to autodetect its version (while still permitting runtime override via the DOCKER_VERSION environment variable). Requests that require an unsupported version are still gated by docker-py's `docker.utils.minimum_version` decorator. 
