### PR TITLE
allow check to sub network for IP match, update docs, add logging

### DIFF
--- a/metadataproxy/roles.py
+++ b/metadataproxy/roles.py
@@ -127,6 +127,15 @@ def find_container(ip):
             log.debug(msg.format(_id, ip))
             CONTAINER_MAPPING[ip] = _id
             return c
+        # Try matching container to caller by sub network IP address
+        _networks = c['NetworkSettings']['Networks']
+        if len(_networks) > 0:
+            for _network in _networks:
+                if _networks[_network]['IPAddress'] == ip:
+                    msg = 'Container id {0} mapped to {1} by sub-network IP match'
+                    log.debug(msg.format(_id, ip))
+                    CONTAINER_MAPPING[ip] = _id
+                    return c
         # Try matching container to caller by hostname match
         if app.config['ROLE_REVERSE_LOOKUP']:
             hostname = c['Config']['Hostname']

--- a/run-server.sh
+++ b/run-server.sh
@@ -8,4 +8,10 @@ if [ "z$PORT" = "z" ]; then
     PORT=8000
 fi
 
-/usr/local/bin/gunicorn metadataproxy:app --workers=2 -k gevent -b $HOST:$PORT
+if [ "$DEBUG" = "True" ]; then
+    LEVEL="debug"
+else
+    LEVEL="warning"
+fi
+
+/usr/local/bin/gunicorn metadataproxy:app --log-level $LEVEL --workers=2 -k gevent -b $HOST:$PORT


### PR DESCRIPTION
Fixes issue #37 with allowing the IP match to check against NetworkSettings:Network:"netname":IPAddress as well as NetworkSettings:IPAddress which is not always set.

Also adds logging via gunicorn and some documentation updates.