### PR TITLE
Support for additional control over assumed roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.2
+
+* Packaging fixes for travis releases to docker hub
+
 ## 1.3.1
 
 * Fix for k8s network lookup stacktrace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.4.0
+
+* Add IAM\_EXTERNAL\_ID variable: if found value will be populated into ExternalId parameter when making AssumeRole call.
+* add ROLE\_SESSION\_KEY variable: if found will use value to look up key from Docker container labels or environment variable to set RoleSessionName when making AssumeRole call. See documentation for details.
+* Reduce number of calls to Docker API when retrieving credentials.
+* Bump WSGI dependency versions
+
 ## 1.3.2
 
 * Packaging fixes for travis releases to docker hub

--- a/metadataproxy/settings.py
+++ b/metadataproxy/settings.py
@@ -55,7 +55,7 @@ def str_env(var_name, default=''):
 
 PORT = int_env('PORT', 45001)
 HOST = str_env('HOST', '0.0.0.0')
-DEBUG = bool_env('DEBUG', True)
+DEBUG = bool_env('DEBUG', False)
 
 # Url of the docker daemon. The default is to access docker via its socket.
 DOCKER_URL = str_env('DOCKER_URL', 'unix://var/run/docker.sock')
@@ -98,3 +98,6 @@ ROLE_REVERSE_LOOKUP = bool_env('ROLE_REVERSE_LOOKUP', False)
 # Limit reverse lookup container matching to hostnames that match the specified
 # pattern.
 HOSTNAME_MATCH_REGEX = str_env('HOSTNAME_MATCH_REGEX', '^.*$')
+# Optional key in container labels or environment variables to use for role session name.
+# Prefix with Labels: or Env: respectively to indicate where key should be found.
+ROLE_SESSION_KEY = str_env('ROLE_SESSION_KEY')

--- a/requirements_wsgi.txt
+++ b/requirements_wsgi.txt
@@ -1,14 +1,14 @@
 # License: MIT
 # Upstream url: http://gunicorn.org/
 # Use: For wsgi running
-gunicorn==19.3.0
+gunicorn==19.7.1
 
 # License: MIT
 # Upstream url: http://www.gevent.org/
 # Use: For concurrency
-gevent==1.0.2
+gevent==1.2.2
 
 # License: MIT
 # Upstream url: https://github.com/python-greenlet/greenlet
 # Use: For concurrency
-greenlet==0.4.9
+greenlet==0.4.12

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ reqs = reqs_base + reqs_wsgi
 
 setup(
     name="metadataproxy",
-    version="1.3.1",
+    version="1.3.2",
     packages=find_packages(exclude=["test*"]),
     include_package_data=True,
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ reqs = reqs_base + reqs_wsgi
 
 setup(
     name="metadataproxy",
-    version="1.3.2",
+    version="1.4.0",
     packages=find_packages(exclude=["test*"]),
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
* IAM_EXTERNAL_ID variable; if found value will be populated into ExternalId parameter when making AssumeRole call.
* ROLE_SESSION_KEY variable; if found will use value to look up key from Docker container labels or environment variable to set RoleSessionName when making AssumeRole call.
* Reduce number of calls to Docker API when retrieving credentials.
* Bump WSGI versions to add support for gunicorn --capture-output option
* Set up logging when not run in debug mode