### PR TITLE
New support retrieving container IP from Rancher labels

### DIFF
--- a/metadataproxy/roles.py
+++ b/metadataproxy/roles.py
@@ -139,7 +139,6 @@ def find_container(ip):
                     CONTAINER_MAPPING[ip] = _id
                     return c
         # Not Found ? Let's see if we are running under rancher 1.2+,which uses a label to store the IP
-        _labels = dict(c['Config']['Labels'])
         try:
             _labels = c.get('Config', {}).get('Labels', {})
         except (KeyError, ValueError):
@@ -147,6 +146,7 @@ def find_container(ip):
         try:
             if _labels.get('io.rancher.container.ip'):
                 ip = _labels.get('io.rancher.container.ip').split("/")[0]
+                print(ip)
         except docker.errors.NotFound:
             log.error('Container: {0} Label container.ip not found'.format(_id))
         if ip == _ip:

--- a/metadataproxy/roles.py
+++ b/metadataproxy/roles.py
@@ -145,8 +145,7 @@ def find_container(ip):
             _labels = {}
         try:
             if _labels.get('io.rancher.container.ip'):
-                ip = _labels.get('io.rancher.container.ip').split("/")[0]
-                print(ip)
+                _ip = _labels.get('io.rancher.container.ip').split("/")[0]
         except docker.errors.NotFound:
             log.error('Container: {0} Label container.ip not found'.format(_id))
         if ip == _ip:
@@ -154,7 +153,6 @@ def find_container(ip):
             log.debug(msg.format(_id, ip))
             CONTAINER_MAPPING[ip] = _id
             return c
-
         # Try matching container to caller by hostname match
         if app.config['ROLE_REVERSE_LOOKUP']:
             hostname = c['Config']['Hostname']

--- a/metadataproxy/roles.py
+++ b/metadataproxy/roles.py
@@ -138,6 +138,23 @@ def find_container(ip):
                     log.debug(msg.format(_id, ip))
                     CONTAINER_MAPPING[ip] = _id
                     return c
+        # Not Found ? Let's see if we are running under rancher 1.2+,which uses a label to store the IP
+        _labels = dict(c['Config']['Labels'])
+        try:
+            _labels = c.get('Config', {}).get('Labels', {})
+        except (KeyError, ValueError):
+            _labels = {}
+        try:
+            if _labels.get('io.rancher.container.ip'):
+                ip = _labels.get('io.rancher.container.ip').split("/")[0]
+        except docker.errors.NotFound:
+            log.error('Container: {0} Label container.ip not found'.format(_id))
+        if ip == _ip:
+            msg = 'Container id {0} mapped to {1} by Rancher IP match'
+            log.debug(msg.format(_id, ip))
+            CONTAINER_MAPPING[ip] = _id
+            return c
+
         # Try matching container to caller by hostname match
         if app.config['ROLE_REVERSE_LOOKUP']:
             hostname = c['Config']['Hostname']


### PR DESCRIPTION
This is a replacement for https://github.com/lyft/metadataproxy/pull/35 which passes the tests and implements the improvements listed on it