### PR TITLE
Use port 4501

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,4 +7,4 @@ if [ ! -z "$DEVBOX" ]; then
   export MOCK_API="true"
   export MOCKED_INSTANCE_ID="onebox"
 fi
-exec gunicorn wsgi:app --bind 0.0.0.0:45001 -c /etc/gunicorn/gunicorn.conf
+exec gunicorn wsgi:app --bind 0.0.0.0:4501 -c /etc/gunicorn/gunicorn.conf

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -12,7 +12,7 @@ containers:
     start_phase: sequential_init
     exports:
       - name: api
-        port: 45001
+        port: 4501
     privileged: True
 
 groups:

--- a/metadataproxy/settings.py
+++ b/metadataproxy/settings.py
@@ -53,7 +53,7 @@ def str_env(var_name, default=''):
     return getenv(var_name, default)
 
 
-PORT = int_env('PORT', 45001)
+PORT = int_env('PORT', 4501)
 HOST = str_env('HOST', '0.0.0.0')
 DEBUG = bool_env('DEBUG', False)
 

--- a/provision.sh
+++ b/provision.sh
@@ -3,7 +3,7 @@ set -e
 DOCKER_GW=$(ip addr show docker0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)
 
 
-if ! iptables --wait -t nat -i docker0 -p tcp --dport 80 --destination 169.254.169.254 --jump DNAT --to-destination "${DOCKER_GW}":45001 -C PREROUTING 2> /dev/null; then
+if ! iptables --wait -t nat -i docker0 -p tcp --dport 80 --destination 169.254.169.254 --jump DNAT --to-destination "${DOCKER_GW}":4501 -C PREROUTING 2> /dev/null; then
   echo "creating ip tables rule ..."
   /sbin/iptables --wait -t nat \
       -A PREROUTING \
@@ -12,5 +12,5 @@ if ! iptables --wait -t nat -i docker0 -p tcp --dport 80 --destination 169.254.1
       --dport 80 \
       --destination 169.254.169.254 \
       --jump DNAT \
-      --to-destination "${DOCKER_GW}":45001
+      --to-destination "${DOCKER_GW}":4501
 fi


### PR DESCRIPTION
`45001` is in the Linux ephemeral port range, and using it might be causing startup failures when destroying and restarting the metadataproxy container. Moving onto `4501` instead.