### PR TITLE
Correct the docker image reference in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ You can build one with the included Dockerfile.  To run, do something like:
 ```bash
 docker run --net=host \
     -v /var/run/docker.sock:/var/run/docker.sock \
-    metadataproxy
+    lyft/metadataproxy
 ```
 
 ### gunicorn settings


### PR DESCRIPTION
The README didn't reference the fully qualified `lyft/metadataproxy` docker image name (it was missing the `lyft` namespace)