### PR TITLE
Disable "front envoy" routes for metadataproxy

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -9,9 +9,6 @@ containers:
     mounts:
       - /var/run/docker_sockets
     start_phase: sequential_init
-    exports:
-      - name: api
-        port: 45001
     privileged: True
 
 groups:


### PR DESCRIPTION
need to be careful this doesn't break things, I haven't had time to verify but wanted to put a review out