### PR TITLE
Upgrade gunicorn for Lyft's MDP

### DIFF
--- a/Dockerfile.private
+++ b/Dockerfile.private
@@ -10,5 +10,7 @@ RUN : \
     && virtualenv /venv -ppython2.7 \
     && pip install -r/code/metadataproxy/requirements_wsgi.txt \
     && pip install -r/code/metadataproxy/requirements.txt
+RUN mkdir -p /etc/gunicorn
+COPY gunicorn.conf /etc/gunicorn/gunicorn.conf
 COPY . /code/metadataproxy/
 ENV DOCKER_URL 'unix://var/run/docker_sockets/docker.sock'

--- a/Dockerfile.private
+++ b/Dockerfile.private
@@ -1,6 +1,14 @@
-FROM lyft/gunicorn:fdbc8191800c582fbf63a208d84842148d1bde6c
-RUN apt-get update -y && apt-get install -y iptables
-COPY requirements.txt /code/metadataproxy/requirements.txt
-RUN /code/containers/python/pip-installer /code/metadataproxy/requirements.txt
+FROM lyft/imagebase:d73781c2355e7b4dd3f04e9bf95a15c40761b359
+RUN : \
+    && apt-get update -y \
+    && apt-get install -y \
+        iptables \
+        python-virtualenv
+ENV PATH=/venv/bin:$PATH
+COPY requirements.txt requirements_wsgi.txt /code/metadataproxy/
+RUN : \
+    && virtualenv /venv -ppython2.7 \
+    && pip install -r/code/metadataproxy/requirements_wsgi.txt \
+    && pip install -r/code/metadataproxy/requirements.txt
 COPY . /code/metadataproxy/
 ENV DOCKER_URL 'unix://var/run/docker_sockets/docker.sock'

--- a/gunicorn.conf
+++ b/gunicorn.conf
@@ -14,7 +14,9 @@ access_log_format  = '"%(r)s" %(s)s %({Content-Length}i)s %(b)s %(D)s "%({X-Forw
 accesslog = '-'
 
 reload = True
-reload_extra_files = ['/root/.aws/credentials']
+if os.getenv('HOST_SERVICE_NAME') == 'devbox':
+    reload_extra_files = ['/root/.aws/credentials']
+
 loglevel = "debug"
 workers = 1
 proc_name = os.getenv('IMAGE_NAME') + "." + os.getenv("CONTAINER_NAME")

--- a/gunicorn.conf
+++ b/gunicorn.conf
@@ -13,15 +13,10 @@ worker_class = "gevent"
 access_log_format  = '"%(r)s" %(s)s %({Content-Length}i)s %(b)s %(D)s "%({X-Forwarded-For}i)s" "%(a)s" - %(u)s "%({X-Request-Id}i)s" "%({Accept}i)s"'
 accesslog = '-'
 
-if os.getenv('SERVICE_INSTANCE') == 'development':
-  reload = True
-  reload_extra_files = ['/root/.aws/credentials']
-  loglevel = "debug"
-  workers = 1
-else:
-  reload = False
-  preload = True
-  workers = multiprocessing.cpu_count() * 2 + 1
+reload = True
+reload_extra_files = ['/root/.aws/credentials']
+loglevel = "debug"
+workers = 1
 proc_name = os.getenv('IMAGE_NAME') + "." + os.getenv("CONTAINER_NAME")
 forwarded_allow_ips = '*'
 

--- a/gunicorn.conf
+++ b/gunicorn.conf
@@ -1,0 +1,40 @@
+import os
+import multiprocessing
+import uuid
+
+bind = "0.0.0.0:80"
+worker_class = "gevent"
+
+# Access log format:
+# [time] "request" status bytes_received bytes_sent microsecond_response_time "X-Forwarded-For_header" "User-Agent_header" obscured_user_id remote_user_header "unique_id" "Accept_header"
+# Use quotes (") for values that may have space in them (eg headers). Gunicorn
+# will automatically escape any quotes in the value:
+#     "my-user-agent-\"-with-quote"
+access_log_format  = '"%(r)s" %(s)s %({Content-Length}i)s %(b)s %(D)s "%({X-Forwarded-For}i)s" "%(a)s" - %(u)s "%({X-Request-Id}i)s" "%({Accept}i)s"'
+accesslog = '-'
+
+if os.getenv('SERVICE_INSTANCE') == 'development':
+  reload = True
+  reload_extra_files = ['/root/.aws/credentials']
+  loglevel = "debug"
+  workers = 1
+else:
+  reload = False
+  preload = True
+  workers = multiprocessing.cpu_count() * 2 + 1
+proc_name = os.getenv('IMAGE_NAME') + "." + os.getenv("CONTAINER_NAME")
+forwarded_allow_ips = '*'
+
+def pre_request(worker, req):
+    pre_request_add_request_id(worker, req)
+
+
+def pre_request_add_request_id(worker, req):
+  for h in req.headers:
+    # all request header name are upper cased in a gunicorn request.
+    if 'X-REQUEST-ID' == h[0]:
+      # There is a X-Request-ID header set. Don't set our own.
+      return
+    # We haven't found a request-id header. Add one with a our own generated
+    # request id.
+    req.headers.append(('X-REQUEST-ID', str(uuid.uuid1())))

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,6 +1,8 @@
 name: metadataproxy
 description: Intercepts calls to EC2 Metadata Service from containers.
 repository: git@github.com:lyft/metadataproxy.git
+pagerduty_escalation_policy: DevX
+team_email: devnull@lyft.com
 containers:
   - name: server
     command: /code/metadataproxy/entrypoint.sh


### PR DESCRIPTION
Using the `lyft/gunicorn:fdbc8191800c582fbf63a208d84842148d1bde6c` image means that gunicorn is stuck on v19.4.5. We need it to be at least 19.8 to enable the `reload_extra_files = ['/root/.aws/credentials']` flag (required because this file will change frequently with ephemeral role credentials).

Changes:

* Switched to using imagebase image
* This imagebase image does not include virtualenv nor does it include /etc/gunicorn/gunicorn.conf so I am adding the installation of virtualenv and also the management of the gunicorn.conf file here (Happy for alternatives for the gunicorn.conf file location)
* Install requirements_wsgi.txt for gunicorn v19.9
