### PR TITLE
ensure all-or-nothing for ARN matching a role

### DIFF
--- a/metadataproxy/roles.py
+++ b/metadataproxy/roles.py
@@ -193,8 +193,8 @@ def get_role_params_from_ip(ip, requested_role=None):
             for e in env:
                 key, val = e.split('=', 1)
                 if key == 'IAM_ROLE':
-                    if val.startswith('arn:aws'):
-                        m = RE_IAM_ARN.match(val)
+                    m = RE_IAM_ARN.match(val)
+                    if m:
                         val = '{0}@{1}'.format(m.group(2), m.group(1))
                     role_name = val
                 elif key == 'IAM_EXTERNAL_ID':


### PR DESCRIPTION
A string that starts with `arn:aws` would match the "oh, extract a role from an ARN" code, but would fail if the regex didn't match. Here's a sample fail:

```
  File "/srv/metadataproxy/metadataproxy/routes/mock.py", line 132, in get_security_credentials_slash
    role_params = roles.get_role_params_from_ip(request.remote_addr)
  File "/srv/metadataproxy/metadataproxy/roles.py", line 59, in timed
    result = method(*args, **kw)
  File "/srv/metadataproxy/metadataproxy/roles.py", line 198, in get_role_params_from_ip
    val = '{0}@{1}'.format(m.group(2), m.group(1))
AttributeError: 'NoneType' object has no attribute 'group'
```

This fixes that by making sure the _regex_ matches, not just a substring that is kinda-sorta-similar to what the regex would do. A case where this might happen is if someone were to use a IAM policy instead of an IAM role.

Note this doesn't fix #85, though I can follow up with a PR if this one is accepted.