### PR TITLE
Add `split_envvar()` method to return key/val or key/None

### DIFF
--- a/metadataproxy/roles.py
+++ b/metadataproxy/roles.py
@@ -216,6 +216,14 @@ def find_mesos_container(ip):
     return None
 
 
+def split_envvar(envvar):
+    """Splits str formatted as `key=val` into [key, val]
+
+    if string is missing an `=val` it will return [key, None]
+    """
+    return (envvar.split('=', 1) + [None])[:2]
+
+
 @log_exec_time
 def get_role_params_from_ip(ip, requested_role=None):
     params = {'name': None, 'account_id': None, 'external_id': None, 'session_name': None}
@@ -232,7 +240,7 @@ def get_role_params_from_ip(ip, requested_role=None):
             env = container['Config']['Env'] or []
             # Look up IAM_ROLE and IAM_EXTERNAL_ID values from environment
             for e in env:
-                key, val = e.split('=', 1)
+                key, val = split_envvar(e)
                 if key == 'IAM_ROLE':
                     m = RE_IAM_ARN.match(val)
                     if m:
@@ -252,7 +260,7 @@ def get_role_params_from_ip(ip, requested_role=None):
                 if skey.startswith('Env:'):
                     skey = skey[4:]
                     for e in env:
-                        key, val = e.split('=', 1)
+                        key, val = split_envvar(e)
                         if skey == key:
                             sval = val
                 elif skey.startswith('Labels:'):


### PR DESCRIPTION
In `roles.py` there are several places where a string representing an envvar (formatted as `key=val`) is split like so:

```python
key, val = e.split('=', 1)
```

It's possible however that these strings can also be formatted as simply `key` due to a nil environment variable being set on the docker container. 

eg: if you launch a container like so: `docker run -e 'FOO' -it ubuntu` when you inspect the container, it's JSON output will look like so:

```
            "Env": [
                "FOO",
                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
            ],
```

The current method of splitting by directly calling `.split` will cause a stack trace in this event, even if the key which is nil is _not_ something we are looking for. 

To prevent that I've simply added a method that will ensure two items are always returned when splitting an envvar string. If an ennvar is nil, the value returned for `val` will be `None`.