### PR TITLE
Make IAM role expiration threshold 15 minutes + configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ script, or set via docker environment variables.
 | MOCK\_API | Boolean | False | Whether or not to mock all metadata endpoints. If True, mocked data will be returned to callers. If False, all endpoints except for IAM endpoints will be proxied through to the real metadata service. |
 | MOCKED\_INSTANCE\_ID | String | mockedid | When mocking the API, use the following instance id in returned data. |
 | AWS\_ACCOUNT\_MAP | JSON String | `{}` | A mapping of account names to account IDs. This allows you to use user-friendly names instead of account IDs in IAM\_ROLE environment variable values. |
+| ROLE\_EXPIRATION\_THRESHOLD | Integer | 15 | The threshold before credentials expire in minutes at which metadataproxy will attempt to load new credentials. |
 | ROLE\_MAPPING\_FILE | Path String | | A json file that has a dict mapping of IP addresses to role names. Can be used if docker networking has been disabled and you are managing IP addressing for containers through another process. |
 | ROLE\_REVERSE\_LOOKUP | Boolean | False | Enable performing a reverse lookup of incoming IP addresses to match containers by hostname. Useful if you've disabled networking in docker, but set hostnames for containers in /etc/hosts or DNS. |
 | HOSTNAME\_MATCH\_REGEX | Regex String | `^.*$` | Limit reverse lookup container matching to hostnames that match the specified pattern. |

--- a/metadataproxy/roles.py
+++ b/metadataproxy/roles.py
@@ -348,7 +348,7 @@ def get_assumed_role(role_params):
         assumed_role = ROLES[arn]
         expiration = assumed_role['Credentials']['Expiration']
         now = datetime.datetime.now(dateutil.tz.tzutc())
-        expire_check = now + datetime.timedelta(minutes=5)
+        expire_check = now + datetime.timedelta(minutes=app.config['ROLE_EXPIRATION_THRESHOLD'])
         if expire_check < expiration:
             return assumed_role
     with PrintingBlockTimer('sts.assume_role'):

--- a/metadataproxy/settings.py
+++ b/metadataproxy/settings.py
@@ -87,6 +87,10 @@ DEFAULT_ACCOUNT_ID = str_env('DEFAULT_ACCOUNT_ID')
 #   account_id: 12345
 AWS_ACCOUNT_MAP = json.loads(str_env('AWS_ACCOUNT_MAP', '{}'))
 
+# The threshold before credentials expire in minutes at which metadataproxy will attempt
+# to load new credentials. The default in previous versions of metadataproxy was 5, but
+# we choose to make the new default 15 for better compatibility with aws-sdk-java.
+ROLE_EXPIRATION_THRESHOLD = int_env('ROLE_EXPIRATION_THRESHOLD', 15)
 # A json file that has a dict mapping of IP addresses to role names. Can be
 # used if docker networking has been disabled and you are managing IP
 # addressing for containers through another process.


### PR DESCRIPTION
Fixes https://github.com/lyft/metadataproxy/issues/94

Hey friends. The linked issue describes the behaviour we're hoping to see addressed by this PR. In short: metadataproxy caches credentials until they are 5 minutes from expiration; this PR would change that threshold to 15 minutes, and also make it configurable.

I realize changing a default value is not always desirable, but if that's the case, our org is mostly interested in making the expiry configurable, even if changing the default is not possible.