### PR TITLE
Refactorator: Apply makeorcastepsexplicit in metadataproxy

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -11,7 +11,7 @@ containers:
     mounts:
       - /var/run/docker_sockets
     start_phase: sequential_init
-    privileged: True
+    privileged: true
 
 groups:
   - name: dev
@@ -24,14 +24,36 @@ tests:
     group: metadataproxy.dev
 deploy:
   - name: development
-    legacy: False
+    legacy: false
+  - name: staging-orca
+    legacy: false
+    kubernetes:
+      enabled: true
+    targets:
+      - facet: orca
+    automatic: false
+    orca: []
   - name: staging
-    legacy: False
+    legacy: false
+    orca: []
+  - name: production-orca
+    legacy: false
+    kubernetes:
+      enabled: true
+    targets:
+      - facet: orca
+    automatic: false
+    orca: []
   - name: canary
-    legacy: False
+    legacy: false
+    orca: []
   - name: production
-    legacy: False
+    legacy: false
 builder:
   name: docker_build
   params:
     dockerfile: Dockerfile.private
+facets:
+  - name: orca
+    type: legacyorca
+    member: metadataproxy.server


### PR DESCRIPTION
Refactorator would like to apply these changes to your code!  Please shepherd this to production as soon as possible, going through the normal deployment process monitoring this PR as you would any other change.

**You do not need to approve or land this PR. It will be merged automatically. You will still need to deploy the merged commit yourself.**

To reproduce these changes locally, run:
```bash
control run refactorator.run fix -i metadataproxy -f makeorcastepsexplicit
```
# makeorcastepsexplicit
State of the world before this refactorator:
  - Orca runs implicitly before the actual "deploy" part of `staging` and `canary` deploy steps.
  - Orca may be run explicitly before the actual "deploy" part of certain deploy steps.

Intended state of the world after this refactorator:
  - Orca is run as a LegacyOrca facet targeted in dedicated deploy steps.
  - Implicit orca runs are disabled. Where it would have been a no-op, it's not explicitly disabled.
  - Explicit orca runs that don't match the default are currently left as-is (to be fixed in a future refactorator).

Motivation: In order to migrate the Deploys Jenkins clusters to Kubernetes, we need to eliminate
certain usages of `control`. The way we run orca is one such usage.


For more information or questions reach out to [#deploys-bots](https://lyft.slack.com/messages/deploys-bots).
