### PR TITLE
Refactorator: Apply removedevstep in metadataproxy

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -11,7 +11,7 @@ containers:
     mounts:
       - /var/run/docker_sockets
     start_phase: sequential_init
-    privileged: True
+    privileged: true
 
 groups:
   - name: dev
@@ -23,14 +23,13 @@ tests:
     type: startup
     group: metadataproxy.dev
 deploy:
-  - name: development
-    legacy: False
   - name: staging
-    legacy: False
+    legacy: false
+    automatic: false
   - name: canary
-    legacy: False
+    legacy: false
   - name: production
-    legacy: False
+    legacy: false
 builder:
   name: docker_build
   params:


### PR DESCRIPTION
Refactorator would like to apply these changes to your code!  Please shepherd this to production as soon as possible, going through the normal deployment process monitoring this PR as you would any other change.

**You do not need to approve or land this PR. It will be merged automatically. You will still need to deploy the merged commit yourself.**

To reproduce these changes locally, run:
```bash
control run refactorator.run fix -i metadataproxy -f removedevstep
```
# removedevstep
Orchestration of AWS resources for **development** has been happening when PRs are merged to master for quite a while, rendering this deployment step unnecessary. We are removing this to speed up your deployments. Please reach out to the Deploys on-call in #dev-environment if you have any questions.

For more information or questions reach out to [#deploys-bots](https://lyft.slack.com/messages/deploys-bots).
