### PR TITLE
Refactorator: Apply setdeploystepenvironment in metadataproxy

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -11,7 +11,7 @@ containers:
     mounts:
       - /var/run/docker_sockets
     start_phase: sequential_init
-    privileged: True
+    privileged: true
 
 groups:
   - name: dev
@@ -24,13 +24,17 @@ tests:
     group: metadataproxy.dev
 deploy:
   - name: development
-    legacy: False
+    legacy: false
+    environment: development
   - name: staging
-    legacy: False
+    legacy: false
+    environment: staging
   - name: canary
-    legacy: False
+    legacy: false
+    environment: production
   - name: production
-    legacy: False
+    legacy: false
+    environment: production
 builder:
   name: docker_build
   params:


### PR DESCRIPTION
Refactorator would like to apply these changes to your code!  Please shepherd this to production as soon as possible, going through the normal deployment process monitoring this PR as you would any other change.

**You do not need to approve or land this PR. It will be merged automatically. You will still need to deploy the merged commit yourself.**

To reproduce these changes locally, run:
```bash
control ensure control.minimal
control run refactorator.run fix -i metadataproxy -f setdeploystepenvironment
```
# setdeploystepenvironment
This refactorator adds an `environment` to deploy steps where it can be trivially inferred (e.g. the name already contains a valid environment).
Deploy steps whose names cannot be trivially inferred will be skipped for now in favor of revisiting later.
This enables the Deploys team to rely on explicit info instead of parsing deploy names.


For more information or questions reach out to [#deploys-bots](https://lyft.slack.com/messages/deploys-bots).
