### PR TITLE
STS regional endpoints support

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ script, or set via docker environment variables.
 | MOCK\_API | Boolean | False | Whether or not to mock all metadata endpoints. If True, mocked data will be returned to callers. If False, all endpoints except for IAM endpoints will be proxied through to the real metadata service. |
 | MOCKED\_INSTANCE\_ID | String | mockedid | When mocking the API, use the following instance id in returned data. |
 | AWS\_ACCOUNT\_MAP | JSON String | `{}` | A mapping of account names to account IDs. This allows you to use user-friendly names instead of account IDs in IAM\_ROLE environment variable values. |
+| AWS\_REGION | String |  | AWS Region for the STS endpoint allow you to call region based endpoint instead of global one. [AWS STS region endpoints.](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html#id_credentials_region-endpoints) |
 | ROLE\_EXPIRATION\_THRESHOLD | Integer | 15 | The threshold before credentials expire in minutes at which metadataproxy will attempt to load new credentials. |
 | ROLE\_MAPPING\_FILE | Path String | | A json file that has a dict mapping of IP addresses to role names. Can be used if docker networking has been disabled and you are managing IP addressing for containers through another process. |
 | ROLE\_REVERSE\_LOOKUP | Boolean | False | Enable performing a reverse lookup of incoming IP addresses to match containers by hostname. Useful if you've disabled networking in docker, but set hostnames for containers in /etc/hosts or DNS. |

--- a/metadataproxy/roles.py
+++ b/metadataproxy/roles.py
@@ -1,17 +1,17 @@
 # Import python libs
 import datetime
-import dateutil.tz
-import logging
 import json
-import socket
+import logging
 import re
+import socket
 import timeit
-import requests
 
 # Import third party libs
 import boto3
+import dateutil.tz
 import docker
 import docker.errors
+import requests
 from botocore.exceptions import ClientError
 from cachetools import cached, TTLCache
 
@@ -82,7 +82,13 @@ def iam_client():
 def sts_client():
     global _sts_client
     if _sts_client is None:
-        _sts_client = boto3.client('sts')
+        aws_region = app.config.get('AWS_REGION')
+
+        _sts_client = boto3.client(
+            service_name='sts',
+            region_name=aws_region,
+            endpoint_url=f'https://sts.{aws_region}.amazonaws.com'
+        ) if aws_region else boto3.client(service_name='sts')
     return _sts_client
 
 

--- a/metadataproxy/settings.py
+++ b/metadataproxy/settings.py
@@ -86,7 +86,8 @@ DEFAULT_ACCOUNT_ID = str_env('DEFAULT_ACCOUNT_ID')
 #   role_name: myrole
 #   account_id: 12345
 AWS_ACCOUNT_MAP = json.loads(str_env('AWS_ACCOUNT_MAP', '{}'))
-
+# AWS Region to resolve region based STS service endpoint and to make calls against it.
+AWS_REGION = str_env('AWS_REGION')
 # The threshold before credentials expire in minutes at which metadataproxy will attempt
 # to load new credentials. The default in previous versions of metadataproxy was 5, but
 # we choose to make the new default 15 for better compatibility with aws-sdk-java.


### PR DESCRIPTION
We faced very nasty STS issue with metadata proxy. 

One of our production regions is located in the `ap-southeast-1` and by default boto3 is trying to global STS endpoint which is located in the `us-east-1` region. Latency for this requests dramatically decreased within last one and half months and we started to reach timeouts for AWS SDK Credential Provider calls.

Override default endpoint url via environment variable is not an option due to this issue https://github.com/boto/boto3/issues/2099.

Within this PR I've added new env variable for the metadata proxy to be able to support regional STS endpoint and be fully backward compatible to the previous version.

This solved our issue with latency and I believe this can be useful for the community. Would appreciate for the quick response as we would prefer to use official version instead of in-house built feature branch version. 

Thanks in advance.