### PR TITLE
Add an option to patch boto to support ecs-server mode of aws-vault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.0
+
+* Added `PATCH_ECS_ALLOWED_HOSTS` config setting, to support aws-vault's --ecs-server option
+
 ## 2.1.0
 
 * Fix for the gunicorn logging run location in gunicorn.conf, when trying to catch an exception that only exists in python3.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ script, or set via docker environment variables.
 | ROLE\_MAPPING\_FILE | Path String | | A json file that has a dict mapping of IP addresses to role names. Can be used if docker networking has been disabled and you are managing IP addressing for containers through another process. |
 | ROLE\_REVERSE\_LOOKUP | Boolean | False | Enable performing a reverse lookup of incoming IP addresses to match containers by hostname. Useful if you've disabled networking in docker, but set hostnames for containers in /etc/hosts or DNS. |
 | HOSTNAME\_MATCH\_REGEX | Regex String | `^.*$` | Limit reverse lookup container matching to hostnames that match the specified pattern. |
+| PATCH_ECS_ALLOWED_HOSTS | String | | Patch botocore's allowed hosts for ContainerMetadataFetcher to support aws-vault's --ecs-server option. This will inject the provided host into the allowed addresses botocore will allow for the AWS_CONTAINER_CREDENTIALS_FULL_URI environment. |
 
 #### Default Roles
 

--- a/metadataproxy/__init__.py
+++ b/metadataproxy/__init__.py
@@ -2,7 +2,6 @@ from flask import Flask
 
 from metadataproxy import settings
 
-
 app = Flask(__name__)
 app.config.from_object(settings)
 app.debug = app.config['DEBUG']

--- a/metadataproxy/__init__.py
+++ b/metadataproxy/__init__.py
@@ -8,7 +8,7 @@ app.debug = app.config['DEBUG']
 
 if app.config['PATCH_ECS_ALLOWED_HOSTS']:
     from botocore.utils import ContainerMetadataFetcher  # NOQA
-    ContainerMetadataFetcher._ALLOWED_HOSTS.append('host.docker.internal')
+    ContainerMetadataFetcher._ALLOWED_HOSTS.append(app.config['PATCH_ECS_ALLOWED_HOSTS'])
 
 if app.config['MOCK_API']:
     from metadataproxy.routes import mock  # NOQA

--- a/metadataproxy/__init__.py
+++ b/metadataproxy/__init__.py
@@ -2,9 +2,14 @@ from flask import Flask
 
 from metadataproxy import settings
 
+
 app = Flask(__name__)
 app.config.from_object(settings)
 app.debug = app.config['DEBUG']
+
+if app.config['PATCH_ECS_ALLOWED_HOSTS']:
+    from botocore.utils import ContainerMetadataFetcher  # NOQA
+    ContainerMetadataFetcher._ALLOWED_HOSTS.append('host.docker.internal')
 
 if app.config['MOCK_API']:
     from metadataproxy.routes import mock  # NOQA

--- a/metadataproxy/settings.py
+++ b/metadataproxy/settings.py
@@ -115,4 +115,4 @@ MESOS_STATE_TIMEOUT = int_env('MESOS_STATE_TIMEOUT', 2)
 # Patch botocore's allowed hosts for ContainerMetadataFetcher to support aws-vault's
 # --ecs-server option. This will inject docker for mac's URL for the host into the
 # allowed addresses botocore will talk to.
-PATCH_ECS_ALLOWED_HOSTS = bool_env('PATCH_ECS_ALLOWED_HOSTS', False)
+PATCH_ECS_ALLOWED_HOSTS = str_env('PATCH_ECS_ALLOWED_HOSTS')

--- a/metadataproxy/settings.py
+++ b/metadataproxy/settings.py
@@ -111,3 +111,8 @@ MESOS_STATE_LOOKUP = bool_env('MESOS_STATE_LOOKUP', False)
 MESOS_STATE_URL = str_env('MESOS_STATE_URL', 'http://localhost:5051/state')
 # Timeout to use when calling the mesos state endpoint
 MESOS_STATE_TIMEOUT = int_env('MESOS_STATE_TIMEOUT', 2)
+
+# Patch botocore's allowed hosts for ContainerMetadataFetcher to support aws-vault's
+# --ecs-server option. This will inject docker for mac's URL for the host into the
+# allowed addresses botocore will talk to.
+PATCH_ECS_ALLOWED_HOSTS = bool_env('PATCH_ECS_ALLOWED_HOSTS', False)

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ reqs = reqs_base + reqs_wsgi
 
 setup(
     name="metadataproxy",
-    version="2.1.0",
+    version="2.2.0",
     packages=find_packages(exclude=["test*"]),
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
aws-vault supports running as an ecs-server, which runs on a random port, on localhost, with a required token. It puts the URL into the environment, and metadataproxy will use that URL, if it's set in the environment. However, docker for mac only allows access to the host through a special hostname. Botocore limits access to a hardcoded set of hostnames and IPs for the URL.

This change patches botocore to inject a provided hostname, if it's set in the environment.