### PR TITLE
Remove orca reference from deploy steps

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -26,15 +26,12 @@ deploy:
   - name: staging
     legacy: false
     environment: staging
-    orca: []
   - name: canary
     legacy: false
     environment: production
-    orca: []
   - name: production
     legacy: false
     environment: production
-    orca: []
 builder:
   name: docker_build
   params:


### PR DESCRIPTION
Orca was already disabled in this way. The reference can now be dropped.